### PR TITLE
add: PERSONA Agent画面の求人票抽出に対応

### DIFF
--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -2,6 +2,7 @@ import { detectAgent } from "@/utils/detector";
 import { extractHrmosAgent } from "@/extractors/hrmos";
 import { extractHerpAgent } from "@/extractors/herp";
 import { extractTalentioAgent } from "@/extractors/talentio";
+import { extractPersonaAgent } from "@/extractors/persona";
 import type { JobPosting } from "@/types/job-posting";
 
 export default defineContentScript({
@@ -9,6 +10,7 @@ export default defineContentScript({
     "*://hrmos.co/agent/corporates/*/jobs/*/detail*",
     "*://agent.herp.cloud/p/*/requisitions/id/*",
     "*://agent.talentio.com/r/ats/requisitions/*/candidates/new*",
+    "*://www.agent.persona-ats.com/*",
   ],
   main() {
     browser.runtime.onMessage.addListener(
@@ -27,8 +29,10 @@ export default defineContentScript({
                 posting = extractHrmosAgent(document, url);
               } else if (ats === "HERP") {
                 posting = extractHerpAgent(document, url);
-              } else {
+              } else if (ats === "TALENTIO") {
                 posting = extractTalentioAgent(document, url);
+              } else {
+                posting = extractPersonaAgent(document, url);
               }
               sendResponse({ data: posting });
             } catch (e) {

--- a/src/extractors/herp.ts
+++ b/src/extractors/herp.ts
@@ -54,6 +54,10 @@ export function extractHerpAgent(doc: Document, url: string): JobPosting {
     insurance: null,
     smoking_policy: null,
     work_style: null,
+    faq: null,
+    scope_change_work: null,
+    scope_change_location: null,
+    reference_url: null,
 
     // エージェント用追記事項
     agent_info: null,

--- a/src/extractors/hrmos.ts
+++ b/src/extractors/hrmos.ts
@@ -61,6 +61,10 @@ export function extractHrmosAgent(doc: Document, url: string): JobPosting {
     insurance: null,
     smoking_policy: null,
     work_style: null,
+    faq: null,
+    scope_change_work: null,
+    scope_change_location: null,
+    reference_url: null,
 
     agent_info: getRowValue(doc, "エージェント向け情報"),
     recruitment_background: null,

--- a/src/extractors/persona.test.ts
+++ b/src/extractors/persona.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { JSDOM } from "jsdom";
+import { extractPersonaAgent } from "./persona";
+
+function createDoc(html: string): Document {
+  return new JSDOM(html).window.document;
+}
+
+describe("extractPersonaAgent", () => {
+  it("extracts job title from header", () => {
+    const doc = createDoc(`
+      <div class="slide_2_header">
+        <div class="q-my-auto">バックエンドエンジニア</div>
+      </div>
+      <table class="q-table"></table>
+    `);
+    const result = extractPersonaAgent(doc, "https://www.agent.persona-ats.com/");
+    expect(result.source_ats).toBe("PERSONA");
+    expect(result.job_title).toBe("バックエンドエンジニア");
+  });
+
+  it("extracts table fields using getRowValue", () => {
+    const doc = createDoc(`
+      <table class="q-table">
+        <tbody>
+          <tr><th>雇用形態</th><td>正社員</td></tr>
+          <tr><th>給与</th><td>年収500万〜800万</td></tr>
+          <tr><th>企業名</th><td>テスト株式会社</td></tr>
+          <tr><th>福利厚生</th><td>リモート可\n書籍購入補助\nフレックス制</td></tr>
+          <tr><th>業務内容の変更の範囲</th><td>会社の定める業務</td></tr>
+          <tr><th>就業場所の変更の範囲</th><td>会社の定める事業所</td></tr>
+          <tr><th>参考URL</th><td>https://example.com/reference</td></tr>
+        </tbody>
+      </table>
+      <div class="slide_2_header"></div>
+    `);
+    const result = extractPersonaAgent(doc, "https://www.agent.persona-ats.com/");
+    expect(result.employment_type).toBe("正社員");
+    expect(result.salary).toBe("年収500万〜800万");
+    expect(result.company).toBe("テスト株式会社");
+    expect(result.benefits).toEqual(["リモート可", "書籍購入補助", "フレックス制"]);
+    expect(result.scope_change_work).toBe("会社の定める業務");
+    expect(result.scope_change_location).toBe("会社の定める事業所");
+    expect(result.reference_url).toBe("https://example.com/reference");
+  });
+
+  it("extracts free-text sections via getSectionValue", () => {
+    const doc = createDoc(`
+      <div class="slide_2_header"></div>
+      <table class="q-table"></table>
+      <div class="row">
+        <span class="q-ml-sm q-my-xs">業務内容</span>
+      </div>
+      <div>サーバーサイド開発全般</div>
+      <div class="row">
+        <span class="q-ml-sm q-my-xs">募集要項</span>
+      </div>
+      <div>3年以上の開発経験</div>
+      <div class="row">
+        <span class="q-ml-sm q-my-xs">よくあるご質問</span>
+      </div>
+      <div>リモート勤務可能です</div>
+      <div class="row">
+        <span class="q-ml-sm q-my-xs">備考</span>
+      </div>
+      <div>特になし</div>
+    `);
+    const result = extractPersonaAgent(doc, "https://www.agent.persona-ats.com/");
+    expect(result.description).toBe("サーバーサイド開発全般");
+    expect(result.qualifications).toBe("3年以上の開発経験");
+    expect(result.faq).toBe("リモート勤務可能です");
+    expect(result.other).toBe("特になし");
+  });
+
+  it("extracts free-text section with sibling fallback", () => {
+    const doc = createDoc(`
+      <div class="slide_2_header"></div>
+      <table class="q-table"></table>
+      <div class="row">
+        <span class="q-ml-sm q-my-xs">業務内容</span>
+      </div>
+      <div></div>
+      <div class="wrapper"></div>
+      <div>ラッパーを挟んだ業務内容</div>
+    `);
+    const result = extractPersonaAgent(doc, "https://www.agent.persona-ats.com/");
+    expect(result.description).toBe("ラッパーを挟んだ業務内容");
+  });
+
+  it("throws on non-job pages", () => {
+    const doc = createDoc("<div></div>");
+    expect(() =>
+      extractPersonaAgent(doc, "https://www.agent.persona-ats.com/"),
+    ).toThrow("PERSONA求人詳細ページを判別できませんでした");
+  });
+});

--- a/src/extractors/persona.ts
+++ b/src/extractors/persona.ts
@@ -1,0 +1,107 @@
+import type { JobPosting } from "@/types/job-posting";
+import { getRowValue, parseList } from "./common";
+
+/** フリーテキストセクション（span.q-ml-sm.q-my-xs）からラベルに一致する値を取得 */
+function getSectionValue(doc: Document, label: string): string | null {
+  const spans = doc.querySelectorAll("span.q-ml-sm.q-my-xs");
+  for (const span of spans) {
+    if (span.textContent?.trim() === label) {
+      const row = span.closest(".row");
+      let current = row?.nextElementSibling || null;
+      for (let i = 0; current && i < 4; i += 1) {
+        if (current.matches(".row") && current.querySelector("span.q-ml-sm.q-my-xs")) {
+          return null;
+        }
+        const text = current.textContent?.trim();
+        if (text) {
+          return text;
+        }
+        current = current.nextElementSibling;
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+export function extractPersonaAgent(
+  doc: Document,
+  url: string,
+): JobPosting {
+  if (!doc.querySelector(".slide_2_header") || !doc.querySelector("table.q-table")) {
+    throw new Error("PERSONA求人詳細ページを判別できませんでした");
+  }
+
+  return {
+    source_ats: "PERSONA",
+
+    // ヘッダー情報
+    job_title:
+      doc.querySelector(".slide_2_header .q-my-auto")?.textContent?.trim() ||
+      null,
+    position: null,
+
+    // フリーテキストセクション
+    description: getSectionValue(doc, "業務内容"),
+    qualifications: getSectionValue(doc, "募集要項"),
+    faq: getSectionValue(doc, "よくあるご質問"),
+    other: getSectionValue(doc, "備考"),
+
+    // テーブル1: 求人条件
+    employment_type: getRowValue(doc, "雇用形態"),
+    probation: getRowValue(doc, "試用期間"),
+    salary: getRowValue(doc, "給与"),
+    location: getRowValue(doc, "勤務地"),
+    work_schedule: getRowValue(doc, "勤務時間"),
+    holidays: getRowValue(doc, "休日"),
+    benefits: parseList(getRowValue(doc, "福利厚生")),
+    insurance: getRowValue(doc, "加入保険"),
+    smoking_policy: getRowValue(doc, "受動喫煙対策"),
+    scope_change_work: getRowValue(doc, "業務内容の変更の範囲"),
+    scope_change_location: getRowValue(doc, "就業場所の変更の範囲"),
+    contract_period: getRowValue(doc, "労働契約の期間に関する事項"),
+
+    // テーブル2: 企業情報
+    company: getRowValue(doc, "企業名"),
+    founded: getRowValue(doc, "設立"),
+    address: getRowValue(doc, "本社所在地"),
+    capital: getRowValue(doc, "資本金"),
+    employees: getRowValue(doc, "従業員数"),
+    business: getRowValue(doc, "事業概要"),
+    company_url: getRowValue(doc, "企業ホームページ"),
+    reference_url: getRowValue(doc, "参考URL"),
+
+    // PERSONA に該当なし
+    requirements: null,
+    preferred: null,
+    ideal_candidate: null,
+    job_details: null,
+    department: null,
+    career_path: null,
+    onboarding: null,
+    work_environment: null,
+    allowances: null,
+    raise_bonus: null,
+    overtime: null,
+    vacation: null,
+    work_style: null,
+    compensation: null,
+    agent_info: null,
+    recruitment_background: null,
+    target: null,
+    headcount: null,
+    selection_process: null,
+    recruitment_period: null,
+    priority: null,
+    target_companies: null,
+    contact: null,
+    representative: null,
+    clients: null,
+    branch_address: null,
+    group_companies: null,
+    company_details: null,
+
+    source_url: url,
+    extracted_at: new Date().toISOString(),
+  };
+}

--- a/src/extractors/talentio.ts
+++ b/src/extractors/talentio.ts
@@ -91,6 +91,11 @@ export function extractTalentioAgent(
     agent_info: getFieldValue(doc, "補足情報"),
     contact: getFieldValue(doc, "担当者連絡先"),
 
+    faq: null,
+    scope_change_work: null,
+    scope_change_location: null,
+    reference_url: null,
+
     // Talentio に該当なし
     qualifications: null,
     job_details: null,

--- a/src/types/job-posting.ts
+++ b/src/types/job-posting.ts
@@ -1,5 +1,5 @@
 export interface JobPosting {
-  source_ats: "HRMOS" | "HERP" | "TALENTIO";
+  source_ats: "HRMOS" | "HERP" | "TALENTIO" | "PERSONA";
 
   // 求人情報
   position: string | null;
@@ -30,6 +30,10 @@ export interface JobPosting {
   insurance: string | null;
   smoking_policy: string | null;
   work_style: string | null;
+  faq: string | null;
+  scope_change_work: string | null;
+  scope_change_location: string | null;
+  reference_url: string | null;
 
   // エージェント向け情報
   agent_info: string | null;

--- a/src/utils/detector.test.ts
+++ b/src/utils/detector.test.ts
@@ -14,6 +14,12 @@ describe("detectAgent", () => {
         "https://agent.talentio.com/r/ats/requisitions/abc/candidates/new",
       ),
     ).toBe("TALENTIO");
+    expect(
+      detectAgent("https://www.agent.persona-ats.com/"),
+    ).toBe("PERSONA");
+    expect(
+      detectAgent("https://www.agent.persona-ats.com/some/path"),
+    ).toBe("PERSONA");
   });
 
   it("returns null for unsupported or invalid URL", () => {

--- a/src/utils/detector.ts
+++ b/src/utils/detector.ts
@@ -1,4 +1,4 @@
-export type AtsType = "HRMOS" | "HERP" | "TALENTIO" | null;
+export type AtsType = "HRMOS" | "HERP" | "TALENTIO" | "PERSONA" | null;
 
 const HRMOS_AGENT_DETAIL_PATH =
   /^\/agent\/corporates\/[^/]+\/jobs\/[^/]+\/detail\/?$/;
@@ -27,6 +27,9 @@ export function detectAgent(url: string): AtsType {
       TALENTIO_AGENT_REQUISITION_PATH.test(target.pathname)
     ) {
       return "TALENTIO";
+    }
+    if (target.hostname === "www.agent.persona-ats.com") {
+      return "PERSONA";
     }
   } catch {
     /* invalid URL */


### PR DESCRIPTION
## Summary
- PERSONA ATS (`www.agent.persona-ats.com`) のAgent画面から求人票JSONを抽出する機能を追加
- テーブル (`getRowValue`) + フリーテキストセクション (`getSectionValue`) のハイブリッド抽出
- 非求人ページでのガード条件、getSectionValueのsibling走査フォールバックを実装
- 新フィールド4つ追加: `faq`, `scope_change_work`, `scope_change_location`, `reference_url`

## Issues
- Closes #18 (P1-High: 非求人ページでの誤抽出防止)
- Closes #19 (P2-Medium: getSectionValueのDOM構造依存の堅牢化)
- Closes #20 (P3-Low: 新規フィールドの抽出テスト追加)

## Changed Files
| File | Change |
|------|--------|
| `src/extractors/persona.ts` | 新規: PERSONAエクストラクター |
| `src/extractors/persona.test.ts` | 新規: テスト5件 |
| `src/types/job-posting.ts` | `PERSONA` + 4新フィールド追加 |
| `src/utils/detector.ts` | PERSONA検出追加 |
| `src/entrypoints/content.ts` | URLマッチ + dispatch追加 |
| `src/extractors/hrmos.ts` | 新フィールドnull追加 |
| `src/extractors/herp.ts` | 新フィールドnull追加 |
| `src/extractors/talentio.ts` | 新フィールドnull追加 |
| `src/utils/detector.test.ts` | PERSONAテストケース追加 |

## Test plan
- [x] `npm run build` 成功
- [x] `npm run test` 全13テスト合格
- [x] Chrome拡張をロードし `www.agent.persona-ats.com` でバッジに「PERSONA」と表示される
- [x] 求人選択状態で「求人票を抽出」→ 全フィールドが含まれるJSONを取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)